### PR TITLE
feat(retrieval): wire all eight engineering Booleans config-driven

### DIFF
--- a/kernel/orchestrator.py
+++ b/kernel/orchestrator.py
@@ -511,6 +511,10 @@ class Orchestrator:
             "paths": [str(p) for p in paths],
             "tokens_in": tokens_in,
             "tokens_out": tokens_out,
+            # Issue #10: bundle telemetry — these are what the eval harness
+            # aggregates per turn to chart engineered-vs-baseline divergence.
+            "tokens_in_context_bundle": int(getattr(bundle, "tokens_estimate", 0)),
+            "flags": dict(getattr(bundle, "flags", {})),
         }
         if error_message is not None:
             entry["error"] = error_message

--- a/kernel/retrieval.py
+++ b/kernel/retrieval.py
@@ -1,52 +1,124 @@
-"""Retrieval — minimal tier order (issue #3).
+"""Retrieval — config-driven tier order with eight engineering Booleans.
 
-The full eight-Boolean wiring (recency weighting, keyword expansion,
-backlink walking, per-domain query tools, etc.) lands in issue #10. This
-module implements only the **minimal** tier order needed for the journal
-query vertical:
+Issue #3 implemented the **minimal** tier order (INDEX -> session -> grep)
+with no config knobs. Issue #10 generalizes that into the eight-Boolean
+config-driven retrieval contract that lets ``configs/default.yaml`` (all
+ON) be measured head-to-head against ``configs/baseline.yaml`` (all OFF).
 
-    1. Read ``vault/_index/INDEX.md``           (vocabulary seed)
-    2. Read ``vault/_index/active_session.md``  (session continuity)
-    3. Grep over ``vault/<domain>/`` for any query token
-    4. Read up to ``max_files`` matching files into the bundle
+Each Boolean controls one observable difference in the ``ContextBundle``:
 
-The bundle this returns is a small immutable structure: ordered snippets
-(what the agent will see) plus a flat list of paths (what the orchestrator
-audits and the journal handler cites).
+  1. ``tiered_retrieval``        — INDEX + session preload (else: skip)
+  2. ``per_domain_shaping``      — register query_finance/inventory/fitness
+  3. ``recency_weighting``       — recency-desc grep order + system-prompt hint
+  4. ``active_session_summary``  — session preload (sub-tier of #1)
+  5. ``vault_index_first``       — INDEX preload (sub-tier of #1)
+  6. ``backlink_expansion``      — register read_backlinks(file, max_hops)
+  7. ``suggested_actions``       — propagated to digests (no retrieval-side effect)
+  8. ``conflict_auto_merge``     — propagated for completeness (no retrieval effect)
 
-Token budget: v1 uses a rough character-count proxy (chars ~ 4x tokens).
-Precise tokenization can be added without changing the public interface.
+The ``ContextBundle`` returned grows four new fields on top of issue #3's
+ordered snippets + path list:
+
+  - ``flags``                    — dict of ON/OFF Booleans for this turn
+  - ``tool_palette``             — frozenset of tool names registered
+  - ``system_prompt_suffix``     — recency directive (when on) for the LLM
+  - ``tokens_estimate`` and ``max_tool_calls`` — runtime caps surfaced to the
+    orchestrator so audit entries can record bundle weight + tool-call cap
+
+Token budget remains a char-count proxy (4 chars ~ 1 token); ``tokens_estimate``
+on the bundle is what the orchestrator audit-logs as
+``tokens_in_context_bundle`` so eval can chart bundle weight per turn.
+
+The kernel never changes when adding a new domain plugin — domain query
+tools are looked up from the domain handler modules at call time, so
+dropping a new ``domains/<name>/handler.py:query_<name>`` is the entire
+registration step (consistent with CLAUDE.md's plugin contract).
 """
 
 from __future__ import annotations
 
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any, Callable, Iterable, Mapping, Optional
 
-__all__ = ["ContextBundle", "Snippet", "gather_context"]
+__all__ = [
+    "ContextBundle",
+    "Snippet",
+    "expand_keywords",
+    "gather_context",
+    "read_backlinks",
+]
+
+
+# ---------------------------------------------------------------------------
+# constants
+# ---------------------------------------------------------------------------
 
 
 _INDEX_RELATIVE = Path("_index") / "INDEX.md"
 _SESSION_RELATIVE = Path("_index") / "active_session.md"
 
 # Token budget is a rough char-count proxy in v1: ~4 chars per token is
-# the typical ASCII estimate. Precise tokenization is issue #10's problem.
+# the typical ASCII estimate. Precise tokenization can swap in later.
 _CHARS_PER_TOKEN = 4
 
 # Sane default file cap so callers that don't configure it still get a
-# bounded bundle. The minimal tier reads at most this many *matched files*.
+# bounded bundle. The grep tier reads at most this many *matched files*.
 _DEFAULT_MAX_FILES = 5
 
-# Pulled from configs/default.yaml to mirror production headroom.
+# Matches configs/default.yaml so callers without explicit config still
+# get production-shaped headroom.
 _DEFAULT_TOKEN_BUDGET = 6000
+_DEFAULT_MAX_TOOL_CALLS = 8
+_DEFAULT_BACKLINK_MAX_HOPS = 1
 
-# Words shorter than this contribute too much noise as grep terms (single
-# letters, articles, etc.). Matches the spirit of the per-domain tooling
-# without pulling in a full stopword list.
+# Words shorter than this contribute too much noise as grep terms.
 _MIN_TERM_LEN = 3
+
+# Filename-date regex: ``YYYY-MM-DD-...md`` is the convention everywhere
+# in the vault, so it serves as a free recency signal when present.
+_FILENAME_DATE_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})")
+
+# Wikilink regex: matches ``[[target]]`` and ``[[target|display]]`` forms.
+_WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+
+# The eight context-engineering Booleans, in canonical order. Default to
+# True so callers without an explicit ``context_engineering`` block get the
+# engineered behavior (preserves issue #3's tests, which pass an empty
+# config and expect INDEX + session loads).
+_BOOLEAN_FLAGS: tuple[tuple[str, bool], ...] = (
+    ("tiered_retrieval", True),
+    ("per_domain_shaping", True),
+    ("recency_weighting", True),
+    ("active_session_summary", True),
+    ("vault_index_first", True),
+    ("backlink_expansion", True),
+    ("suggested_actions", True),
+    ("conflict_auto_merge", True),
+)
+
+# Tool names — held in module-level frozensets so callers can do membership
+# tests without re-creating sets per call.
+_FILESYSTEM_TOOLS = frozenset({"read_file", "grep", "list_dir"})
+_INDEX_TOOLS = frozenset({"read_index", "read_session"})
+_DOMAIN_TOOLS = frozenset({"query_finance", "query_inventory", "query_fitness"})
+_EXPANSION_TOOLS = frozenset({"expand_keywords", "read_backlinks"})
+
+# System-prompt suffix appended when ``recency_weighting=true``. Concise
+# directive — the agent already has the dated filenames as the primary
+# signal; this just nudges the prompt.
+_RECENCY_SUFFIX = (
+    "When ranking matches, prefer files with the most recent filename date "
+    "(YYYY-MM-DD-*.md) or the highest mtime; recent files are typically "
+    "the most relevant signal for personal-vault queries."
+)
+
+
+# ---------------------------------------------------------------------------
+# public dataclasses
+# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
@@ -59,15 +131,30 @@ class Snippet:
 
 @dataclass(frozen=True)
 class ContextBundle:
-    """Ordered context the orchestrator hands to the LLM + the audit trail.
+    """Ordered context the orchestrator hands to the LLM + audit trail.
 
     Attributes:
         snippets: ordered tier output — INDEX, session, then matched files.
         paths: flat list of every file consulted (for audit + citation).
+        flags: which engineering Booleans were ON for this turn (audit).
+        tool_palette: frozenset of tool names registered for the agent.
+        system_prompt_suffix: extra system-prompt text (e.g., recency hint).
+        tokens_estimate: char-proxy estimate of the bundle's token weight.
+        max_tool_calls: cap on per-turn tool calls — runtime hint to the agent.
     """
 
     snippets: tuple[Snippet, ...]
     paths: tuple[Path, ...]
+    flags: Mapping[str, bool] = field(default_factory=dict)
+    tool_palette: frozenset[str] = field(default_factory=frozenset)
+    system_prompt_suffix: str = ""
+    tokens_estimate: int = 0
+    max_tool_calls: int = _DEFAULT_MAX_TOOL_CALLS
+
+
+# ---------------------------------------------------------------------------
+# small helpers
+# ---------------------------------------------------------------------------
 
 
 def _read_text_safely(path: Path) -> str | None:
@@ -85,6 +172,38 @@ def _retrieval_section(config: Mapping[str, Any] | None) -> Mapping[str, Any]:
     return config.get("retrieval") or {}
 
 
+def _context_engineering_section(
+    config: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    """Pull ``context_engineering`` (or empty) from a config map."""
+    if not config:
+        return {}
+    return config.get("context_engineering") or {}
+
+
+def _flag(config: Mapping[str, Any] | None, name: str, default: bool) -> bool:
+    """Resolve a single Boolean flag from the config with a default fallback."""
+    ce = _context_engineering_section(config)
+    if name in ce:
+        return bool(ce.get(name))
+    # Flat-shape fallback for callers that hand us a denormalized dict.
+    if isinstance(config, Mapping) and name in config:
+        return bool(config.get(name))
+    return default
+
+
+def _resolve_flags(config: Mapping[str, Any] | None) -> dict[str, bool]:
+    """Resolve every Boolean flag into a flat dict for the bundle's audit."""
+    flags = {name: _flag(config, name, default) for name, default in _BOOLEAN_FLAGS}
+    # ``conflict_auto_merge`` lives under sync — let it override the
+    # context_engineering default when present so the bundle reflects the
+    # actual sync config the conflict_watcher will see.
+    sync = (config or {}).get("sync") or {} if isinstance(config, Mapping) else {}
+    if isinstance(sync, Mapping) and "conflict_auto_merge" in sync:
+        flags["conflict_auto_merge"] = bool(sync.get("conflict_auto_merge"))
+    return flags
+
+
 def _budget_chars(config: Mapping[str, Any] | None) -> int:
     """Return the char-count budget derived from ``retrieval.context_token_budget``."""
     retrieval = _retrieval_section(config)
@@ -92,10 +211,22 @@ def _budget_chars(config: Mapping[str, Any] | None) -> int:
     return max(0, budget) * _CHARS_PER_TOKEN
 
 
+def _max_tool_calls(config: Mapping[str, Any] | None) -> int:
+    """Return the per-turn tool-call cap from ``retrieval.max_tool_calls_per_turn``."""
+    retrieval = _retrieval_section(config)
+    return max(1, int(retrieval.get("max_tool_calls_per_turn", _DEFAULT_MAX_TOOL_CALLS)))
+
+
 def _max_files(config: Mapping[str, Any] | None) -> int:
     """Return the cap on matched-file reads from the retrieval config."""
     retrieval = _retrieval_section(config)
     return int(retrieval.get("max_files", _DEFAULT_MAX_FILES))
+
+
+def _backlink_max_hops(config: Mapping[str, Any] | None) -> int:
+    """Return the backlink walk depth cap from the context_engineering config."""
+    ce = _context_engineering_section(config)
+    return max(0, int(ce.get("backlink_max_hops", _DEFAULT_BACKLINK_MAX_HOPS)))
 
 
 def _tokenize_query(query: str) -> tuple[str, ...]:
@@ -105,7 +236,7 @@ def _tokenize_query(query: str) -> tuple[str, ...]:
 
 
 def _line_matches_any(line: str, terms: Iterable[str]) -> bool:
-    """Cheap substring match — sufficient for v1; expansion is issue #10."""
+    """Cheap substring match — sufficient for v1."""
     lowered = line.lower()
     return any(term in lowered for term in terms)
 
@@ -126,15 +257,45 @@ def _file_matches_query(path: Path, terms: tuple[str, ...]) -> bool:
     return False
 
 
-def _iter_domain_files(vault_root: Path, domain: str) -> Iterable[Path]:
-    """Yield every ``.md`` file under ``<vault>/<domain>/`` in stable order."""
+def _filename_date(path: Path) -> str | None:
+    """Extract the leading ``YYYY-MM-DD`` from a filename, if any."""
+    match = _FILENAME_DATE_RE.match(path.name)
+    return match.group(1) if match else None
+
+
+def _safe_mtime(path: Path) -> float:
+    """Return mtime or 0.0 for files that vanished mid-iteration."""
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _iter_domain_files(
+    vault_root: Path,
+    domain: str,
+    *,
+    recency_weighted: bool,
+) -> tuple[Path, ...]:
+    """Return every ``.md`` under ``<vault>/<domain>/`` in the requested order.
+
+    When ``recency_weighted`` is True: most-recent filename date first
+    (with mtime as tie-break for files lacking a date prefix), matching
+    the YYYY-MM-DD convention everywhere in the vault. When False:
+    plain alphabetical ascending — the unhinted baseline order.
+    """
     domain_dir = vault_root / domain
     if not domain_dir.exists():
         return ()
-    # Sorted so retrieval is deterministic across runs (filenames carry dates,
-    # so "lexicographic descending" doubles as "recency descending" for the
-    # ``YYYY-MM-DD-*.md`` convention — issue #10 will weight this explicitly).
-    return sorted(domain_dir.glob("*.md"), reverse=True)
+    files = list(domain_dir.glob("*.md"))
+    if recency_weighted:
+        files.sort(
+            key=lambda p: (_filename_date(p) or "", _safe_mtime(p), p.name),
+            reverse=True,
+        )
+    else:
+        files.sort(key=lambda p: p.name)
+    return tuple(files)
 
 
 def _push_within_budget(
@@ -146,9 +307,9 @@ def _push_within_budget(
 ) -> int:
     """Append ``candidate`` if it fits the remaining budget; return new used total.
 
-    Truncates the candidate's text rather than dropping it entirely when the
-    remaining budget is positive but smaller than the snippet — keeps the
-    provenance link even if the body is partial.
+    Truncates the candidate's text rather than dropping it entirely when
+    the remaining budget is positive but smaller than the snippet — keeps
+    the provenance link even if the body is partial.
     """
     if budget_chars <= 0:
         snippets.append(candidate)
@@ -166,6 +327,175 @@ def _push_within_budget(
     return budget_chars
 
 
+# ---------------------------------------------------------------------------
+# public tools: expand_keywords + read_backlinks
+# ---------------------------------------------------------------------------
+
+
+def expand_keywords(
+    seed_query: str,
+    *,
+    invoker: Optional[Callable[..., Any]] = None,
+    max_terms: int = 8,
+) -> list[str]:
+    """LLM-driven synonym + related-term expansion of a seed query.
+
+    Available regardless of toggle (per kernel/RETRIEVAL.md), but used by
+    retrieval ONLY when ``tiered_retrieval`` AND ``vault_index_first`` are
+    both ON. The LLM round-trip is via the supplied ``invoker`` (defaults
+    to ``kernel.claude_runner.invoke`` so production callers don't have to
+    wire it explicitly; tests inject a deterministic stand-in).
+
+    The seed term is always returned first so callers can splice the
+    result straight into a grep without re-adding the original.
+
+    Args:
+        seed_query: the user's question or topic.
+        invoker: pluggable LLM call. Tests pass a stub.
+        max_terms: cap on returned terms (seed counts toward the cap).
+
+    Returns:
+        Ordered list of terms, seed first, no duplicates, lowercased.
+    """
+    seed = (seed_query or "").strip()
+    if not seed:
+        return []
+
+    if invoker is None:
+        # Lazy import keeps the module import graph small for tests
+        # that monkeypatch around the kernel.
+        from kernel.claude_runner import invoke as claude_invoke  # noqa: WPS433
+
+        invoker = claude_invoke
+
+    prompt = (
+        "Expand the following query into a comma-separated list of "
+        "synonyms and closely related terms suitable for grep over a "
+        "personal markdown vault. Return only the comma-separated list, "
+        "no preamble.\n\n"
+        f"Query: {seed}"
+    )
+
+    try:
+        response = invoker(prompt)
+    except Exception:  # noqa: BLE001
+        # Expansion is opportunistic — never fail retrieval if the LLM
+        # can't be reached. The seed alone keeps grep working.
+        return [seed.lower()]
+
+    raw_text = getattr(response, "text", "") or ""
+    candidates = [seed.lower()]
+    seen: set[str] = {seed.lower()}
+    for chunk in raw_text.replace("\n", ",").split(","):
+        term = chunk.strip().lower()
+        if not term or term in seen:
+            continue
+        candidates.append(term)
+        seen.add(term)
+        if len(candidates) >= max_terms:
+            break
+    return candidates
+
+
+def read_backlinks(
+    file_path: str | os.PathLike[str],
+    *,
+    vault_root: str | os.PathLike[str],
+    max_hops: int = _DEFAULT_BACKLINK_MAX_HOPS,
+) -> list[Path]:
+    """Walk ``[[wikilinks]]`` outward from ``file_path`` up to ``max_hops``.
+
+    Returns the *resolved* neighbor paths in BFS order, deduplicated, never
+    including the seed file. Resolution is permissive: a wikilink target
+    matches any ``.md`` file under ``vault_root`` whose stem equals the
+    target (case-insensitive).
+
+    Args:
+        file_path: starting file. Missing file -> empty list.
+        vault_root: vault root for path resolution.
+        max_hops: hop cap (0 = no walk, 1 = direct neighbors only).
+
+    Returns:
+        Ordered list of resolved neighbor paths, BFS order, no duplicates.
+    """
+    seed = Path(file_path)
+    root = Path(vault_root)
+    if max_hops <= 0 or not seed.exists() or not root.exists():
+        return []
+
+    # Pre-build a stem -> path map once so per-link resolution is O(1).
+    stem_to_paths: dict[str, list[Path]] = {}
+    for candidate in root.rglob("*.md"):
+        stem_to_paths.setdefault(candidate.stem.lower(), []).append(candidate)
+
+    visited: set[Path] = {seed.resolve()}
+    frontier: list[Path] = [seed]
+    out: list[Path] = []
+
+    for _ in range(max_hops):
+        next_frontier: list[Path] = []
+        for current in frontier:
+            text = _read_text_safely(current)
+            if text is None:
+                continue
+            for match in _WIKILINK_RE.finditer(text):
+                target = match.group(1).strip()
+                if not target:
+                    continue
+                resolved = stem_to_paths.get(target.lower()) or []
+                for hit in resolved:
+                    real = hit.resolve()
+                    if real in visited:
+                        continue
+                    visited.add(real)
+                    out.append(hit)
+                    next_frontier.append(hit)
+        frontier = next_frontier
+        if not frontier:
+            break
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# tool palette assembly
+# ---------------------------------------------------------------------------
+
+
+def _assemble_tool_palette(flags: Mapping[str, bool]) -> frozenset[str]:
+    """Compose the tool palette the agent sees, from the resolved flags.
+
+    The palette is the *registered* surface — what the agent CAN call. The
+    *runtime* cap ``max_tool_calls_per_turn`` is conveyed separately on the
+    bundle so the agent prompt can say "you may make at most N tool calls".
+    Registering more tools than the cap is intentional: the agent picks
+    the right N out of M available; truncating the palette would force the
+    kernel to guess priorities.
+    """
+    tools: set[str] = set(_FILESYSTEM_TOOLS)
+    # Index tools ride along with tiered_retrieval (since INDEX + session
+    # are the entry points of the tier order).
+    if flags.get("tiered_retrieval", False):
+        tools |= _INDEX_TOOLS
+    if flags.get("per_domain_shaping", False):
+        tools |= _DOMAIN_TOOLS
+    if flags.get("backlink_expansion", False):
+        tools.add("read_backlinks")
+    # ``expand_keywords`` is exposed when both tiered_retrieval and
+    # vault_index_first are on (per kernel/RETRIEVAL.md). It still exists
+    # as a callable regardless, but the *tool palette* surface is gated.
+    if flags.get("tiered_retrieval", False) and flags.get(
+        "vault_index_first", False
+    ):
+        tools.add("expand_keywords")
+    return frozenset(tools)
+
+
+# ---------------------------------------------------------------------------
+# main entry point
+# ---------------------------------------------------------------------------
+
+
 def gather_context(
     *,
     query: str,
@@ -173,57 +503,82 @@ def gather_context(
     vault_root: str | os.PathLike[str],
     domain: str,
 ) -> ContextBundle:
-    """Run the minimal tier sequence and return what the agent will see.
+    """Run the configured tier sequence and return what the agent will see.
 
     Args:
         query: the user's question — drives grep over the domain dir.
-        config: retrieval-shaped config map. Reads ``retrieval.context_token_budget``
-            and ``retrieval.max_files``; both have safe defaults.
+        config: full kernel config map. Reads ``retrieval.*`` and
+            ``context_engineering.*``; any missing key falls back to a
+            default that preserves issue #3's behavior.
         vault_root: vault root on disk. Missing paths degrade gracefully.
         domain: which ``vault/<domain>/`` directory to grep.
 
     Returns:
-        A ``ContextBundle`` with ordered snippets and a flat path list.
+        A ``ContextBundle`` with ordered snippets, consulted paths, the
+        flags that were ON for this turn, the registered tool palette,
+        the system-prompt suffix, and the char-proxy token estimate.
     """
     root = Path(vault_root)
+    flags = _resolve_flags(config)
+    max_tool_calls = _max_tool_calls(config)
+    tool_palette = _assemble_tool_palette(flags)
+
+    suffix = _RECENCY_SUFFIX if flags.get("recency_weighting", False) else ""
+
     if not root.exists():
-        return ContextBundle(snippets=(), paths=())
+        return ContextBundle(
+            snippets=(),
+            paths=(),
+            flags=flags,
+            tool_palette=tool_palette,
+            system_prompt_suffix=suffix,
+            tokens_estimate=0,
+            max_tool_calls=max_tool_calls,
+        )
 
     budget = _budget_chars(config)
     max_files = _max_files(config)
-
     snippets: list[Snippet] = []
     paths: list[Path] = []
     used = 0
 
-    # Tier 1 — INDEX.md
-    index_path = root / _INDEX_RELATIVE
-    index_text = _read_text_safely(index_path)
-    if index_text is not None:
-        used = _push_within_budget(
-            snippets,
-            Snippet(source=str(index_path), text=index_text),
-            budget_chars=budget,
-            used_chars=used,
-        )
-        paths.append(index_path)
+    tiered = flags.get("tiered_retrieval", False)
+    load_index = tiered and flags.get("vault_index_first", False)
+    load_session = tiered and flags.get("active_session_summary", False)
+    recency = flags.get("recency_weighting", False)
 
-    # Tier 2 — active_session.md
-    session_path = root / _SESSION_RELATIVE
-    session_text = _read_text_safely(session_path)
-    if session_text is not None:
-        used = _push_within_budget(
-            snippets,
-            Snippet(source=str(session_path), text=session_text),
-            budget_chars=budget,
-            used_chars=used,
-        )
-        paths.append(session_path)
+    # Tier 1 — INDEX.md (if both tiered_retrieval and vault_index_first ON).
+    if load_index:
+        index_path = root / _INDEX_RELATIVE
+        index_text = _read_text_safely(index_path)
+        if index_text is not None:
+            used = _push_within_budget(
+                snippets,
+                Snippet(source=str(index_path), text=index_text),
+                budget_chars=budget,
+                used_chars=used,
+            )
+            paths.append(index_path)
 
-    # Tier 3 + 4 — grep over <domain>/ then read top matches
+    # Tier 2 — active_session.md (if both tiered_retrieval and active_session_summary ON).
+    if load_session:
+        session_path = root / _SESSION_RELATIVE
+        session_text = _read_text_safely(session_path)
+        if session_text is not None:
+            used = _push_within_budget(
+                snippets,
+                Snippet(source=str(session_path), text=session_text),
+                budget_chars=budget,
+                used_chars=used,
+            )
+            paths.append(session_path)
+
+    # Tier 3 + 4 — grep over <domain>/ then read top matches.
+    # Recency_weighting controls the order of results; it does NOT gate
+    # whether grep runs — grep is the always-on minimum.
     terms = _tokenize_query(query)
     matches: list[Path] = []
-    for candidate in _iter_domain_files(root, domain):
+    for candidate in _iter_domain_files(root, domain, recency_weighted=recency):
         if len(matches) >= max_files:
             break
         if _file_matches_query(candidate, terms):
@@ -241,4 +596,14 @@ def gather_context(
         )
         paths.append(matched)
 
-    return ContextBundle(snippets=tuple(snippets), paths=tuple(paths))
+    tokens_estimate = sum(len(s.text) for s in snippets) // _CHARS_PER_TOKEN
+
+    return ContextBundle(
+        snippets=tuple(snippets),
+        paths=tuple(paths),
+        flags=flags,
+        tool_palette=tool_palette,
+        system_prompt_suffix=suffix,
+        tokens_estimate=tokens_estimate,
+        max_tool_calls=max_tool_calls,
+    )

--- a/tests/test_orchestrator_retrieval_audit.py
+++ b/tests/test_orchestrator_retrieval_audit.py
@@ -1,0 +1,252 @@
+"""Issue #10 — orchestrator records bundle telemetry on read audit entries.
+
+When the orchestrator gathers a context bundle for a journal query, the
+resulting audit ``read`` entry must carry:
+
+  - ``tokens_in_context_bundle``: the bundle's char-proxy token estimate
+  - ``flags``: the eight engineering Booleans that were ON for this turn
+
+These fields are what the eval harness aggregates to produce per-turn
+charts of bundle weight + flag effects.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import yaml
+
+from kernel.classifier import Classifier
+from kernel.claude_runner import ClaudeResponse
+from kernel.orchestrator import Orchestrator, SingleInstanceLock
+
+
+def _stub_invoker(text: str = "stubbed", tokens_in: int = 1, tokens_out: int = 1):
+    def _invoke(prompt, *, system_prompt: Optional[str] = None):
+        return ClaudeResponse(
+            text=text,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            raw={"prompt": prompt, "system_prompt": system_prompt},
+        )
+
+    return _invoke
+
+
+def _seed_journal_domain(domains_root: Path) -> None:
+    domain_dir = domains_root / "journal"
+    domain_dir.mkdir(parents=True, exist_ok=True)
+    (domain_dir / "domain.yaml").write_text(
+        "name: journal\n"
+        "description: \"narrative\"\n"
+        "intents:\n"
+        "  - journal.capture\n"
+        "  - journal.query\n",
+        encoding="utf-8",
+    )
+
+
+def _seed_vault(vault_root: Path) -> None:
+    (vault_root / "_index").mkdir(parents=True, exist_ok=True)
+    (vault_root / "journal").mkdir(parents=True, exist_ok=True)
+    (vault_root / "_index" / "INDEX.md").write_text(
+        "# INDEX\n\nconsciousness, qualia\n", encoding="utf-8"
+    )
+    (vault_root / "_index" / "active_session.md").write_text(
+        "session: thinking\n", encoding="utf-8"
+    )
+    (vault_root / "journal" / "2026-04-15-consciousness.md").write_text(
+        "thoughts on consciousness\n", encoding="utf-8"
+    )
+
+
+def _fixed_clock() -> datetime:
+    return datetime(2026, 4, 29, 12, 30, 0, tzinfo=timezone.utc)
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _load_config(name: str) -> dict:
+    return yaml.safe_load(
+        (_project_root() / "configs" / f"{name}.yaml").read_text(encoding="utf-8")
+    ) or {}
+
+
+def _orchestrator_for(
+    *,
+    config: dict,
+    config_label: str,
+    vault_root: Path,
+    domains_root: Path,
+    lock_path: Path,
+) -> Orchestrator:
+    classifier = Classifier(
+        domains_root=domains_root,
+        invoker=_stub_invoker(text="journal.query"),
+        prompt_template="",
+    )
+    return Orchestrator(
+        lock=SingleInstanceLock(lock_path),
+        audit_root=vault_root / "_audit",
+        invoker=_stub_invoker(text="answered"),
+        classifier=classifier,
+        vault_root=vault_root,
+        clock=_fixed_clock,
+        chat_id="test-chat",
+        config=config,
+        config_label=config_label,
+    )
+
+
+def _read_audit_entries(vault_root: Path) -> list[dict]:
+    audit_files = list((vault_root / "_audit").glob("*.jsonl"))
+    if not audit_files:
+        return []
+    return [
+        json.loads(line)
+        for line in audit_files[0].read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+# -- audit fields --------------------------------------------------------
+
+
+def test_audit_read_entry_records_tokens_in_context_bundle(
+    tmp_path: Path, lock_path: Path
+) -> None:
+    vault_root = tmp_path / "vault"
+    domains_root = tmp_path / "domains"
+    _seed_journal_domain(domains_root)
+    _seed_vault(vault_root)
+
+    orchestrator = _orchestrator_for(
+        config=_load_config("default"),
+        config_label="default",
+        vault_root=vault_root,
+        domains_root=domains_root,
+        lock_path=lock_path,
+    )
+
+    orchestrator.handle_message("what did I think about consciousness?")
+
+    entries = _read_audit_entries(vault_root)
+    read_entries = [e for e in entries if e["op"] == "read"]
+    assert len(read_entries) == 1
+    record = read_entries[0]
+    assert "tokens_in_context_bundle" in record
+    assert isinstance(record["tokens_in_context_bundle"], int)
+    assert record["tokens_in_context_bundle"] >= 0
+
+
+def test_audit_read_entry_records_flags(
+    tmp_path: Path, lock_path: Path
+) -> None:
+    vault_root = tmp_path / "vault"
+    domains_root = tmp_path / "domains"
+    _seed_journal_domain(domains_root)
+    _seed_vault(vault_root)
+
+    orchestrator = _orchestrator_for(
+        config=_load_config("default"),
+        config_label="default",
+        vault_root=vault_root,
+        domains_root=domains_root,
+        lock_path=lock_path,
+    )
+
+    orchestrator.handle_message("what did I think about consciousness?")
+
+    entries = _read_audit_entries(vault_root)
+    read_entries = [e for e in entries if e["op"] == "read"]
+    record = read_entries[0]
+    flags = record.get("flags") or {}
+    # Default config = all eight Booleans ON.
+    assert flags["tiered_retrieval"] is True
+    assert flags["per_domain_shaping"] is True
+    assert flags["recency_weighting"] is True
+    assert flags["active_session_summary"] is True
+    assert flags["vault_index_first"] is True
+    assert flags["backlink_expansion"] is True
+    assert flags["suggested_actions"] is True
+    assert flags["conflict_auto_merge"] is True
+
+
+def test_audit_read_entry_under_baseline_records_all_off_flags(
+    tmp_path: Path, lock_path: Path
+) -> None:
+    vault_root = tmp_path / "vault"
+    domains_root = tmp_path / "domains"
+    _seed_journal_domain(domains_root)
+    _seed_vault(vault_root)
+
+    orchestrator = _orchestrator_for(
+        config=_load_config("baseline"),
+        config_label="baseline",
+        vault_root=vault_root,
+        domains_root=domains_root,
+        lock_path=lock_path,
+    )
+
+    orchestrator.handle_message("what did I think about consciousness?")
+
+    entries = _read_audit_entries(vault_root)
+    read_entries = [e for e in entries if e["op"] == "read"]
+    record = read_entries[0]
+    flags = record.get("flags") or {}
+    assert flags["tiered_retrieval"] is False
+    assert flags["per_domain_shaping"] is False
+    assert flags["vault_index_first"] is False
+    assert flags["conflict_auto_merge"] is False
+
+
+def test_audit_read_default_records_higher_token_count_than_baseline(
+    tmp_path: Path, lock_path: Path
+) -> None:
+    """Default config preloads INDEX + session, so its bundle is heavier."""
+    # default vault
+    default_vault = tmp_path / "vault-default"
+    default_domains = tmp_path / "domains-default"
+    _seed_journal_domain(default_domains)
+    _seed_vault(default_vault)
+
+    default_orch = _orchestrator_for(
+        config=_load_config("default"),
+        config_label="default",
+        vault_root=default_vault,
+        domains_root=default_domains,
+        lock_path=tmp_path / "default.lock",
+    )
+    default_orch.handle_message("consciousness?")
+
+    # baseline vault
+    baseline_vault = tmp_path / "vault-baseline"
+    baseline_domains = tmp_path / "domains-baseline"
+    _seed_journal_domain(baseline_domains)
+    _seed_vault(baseline_vault)
+
+    baseline_orch = _orchestrator_for(
+        config=_load_config("baseline"),
+        config_label="baseline",
+        vault_root=baseline_vault,
+        domains_root=baseline_domains,
+        lock_path=tmp_path / "baseline.lock",
+    )
+    baseline_orch.handle_message("consciousness?")
+
+    default_entries = _read_audit_entries(default_vault)
+    baseline_entries = _read_audit_entries(baseline_vault)
+    default_tokens = next(
+        e for e in default_entries if e["op"] == "read"
+    )["tokens_in_context_bundle"]
+    baseline_tokens = next(
+        e for e in baseline_entries if e["op"] == "read"
+    )["tokens_in_context_bundle"]
+
+    assert default_tokens > baseline_tokens

--- a/tests/test_retrieval_booleans.py
+++ b/tests/test_retrieval_booleans.py
@@ -1,0 +1,516 @@
+"""Issue #10 — eight engineering Booleans wired into retrieval.
+
+Each Boolean is exercised in isolation: an ON config and an OFF config are
+applied to the same fixture vault for the same query, and the resulting
+``ContextBundle`` is asserted to differ in the way the spec demands.
+
+The portfolio claim is the load-bearing test at the bottom of this file:
+loading the real ``configs/default.yaml`` and ``configs/baseline.yaml`` and
+showing the bundles diverge on every dimension simultaneously.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from kernel.retrieval import ContextBundle, gather_context
+
+
+# -- helpers --------------------------------------------------------------
+
+
+def _seed_vault(
+    vault_root: Path,
+    *,
+    with_index: bool = True,
+    with_session: bool = True,
+    journal_files: list[tuple[str, str]] | None = None,
+) -> dict[str, Path]:
+    """Build a small but realistic vault layout under ``vault_root``."""
+    paths: dict[str, Path] = {}
+
+    if with_index:
+        index = vault_root / "_index" / "INDEX.md"
+        index.parent.mkdir(parents=True, exist_ok=True)
+        index.write_text(
+            "# INDEX\n\nclusters:\n- consciousness, qualia, awareness\n",
+            encoding="utf-8",
+        )
+        paths["index"] = index
+
+    if with_session:
+        session = vault_root / "_index" / "active_session.md"
+        session.parent.mkdir(parents=True, exist_ok=True)
+        session.write_text(
+            "session: previously discussed consciousness\n",
+            encoding="utf-8",
+        )
+        paths["session"] = session
+
+    journal_dir = vault_root / "journal"
+    journal_dir.mkdir(parents=True, exist_ok=True)
+    if journal_files is None:
+        journal_files = [
+            ("2026-04-01-consciousness.md", "thoughts on consciousness today"),
+            ("2026-04-20-consciousness.md", "more on consciousness this week"),
+        ]
+    for name, body in journal_files:
+        target = journal_dir / name
+        target.write_text(body, encoding="utf-8")
+        paths[name] = target
+
+    return paths
+
+
+def _config(**overrides) -> dict:
+    """Build a config dict with default-on flags, overridden by kwargs."""
+    flags = {
+        "tiered_retrieval": True,
+        "per_domain_shaping": True,
+        "recency_weighting": True,
+        "recency_half_life_days": 14,
+        "active_session_summary": True,
+        "vault_index_first": True,
+        "backlink_expansion": True,
+        "backlink_max_hops": 1,
+        "suggested_actions": True,
+    }
+    flags.update(overrides)
+    return {
+        "retrieval": {
+            "context_token_budget": 6000,
+            "max_tool_calls_per_turn": 8,
+            "max_files": 5,
+        },
+        "context_engineering": flags,
+        "sync": {"conflict_auto_merge": True},
+    }
+
+
+def _all_off_config(**overrides) -> dict:
+    """Build a config dict with every Boolean OFF, overridden by kwargs."""
+    flags = {
+        "tiered_retrieval": False,
+        "per_domain_shaping": False,
+        "recency_weighting": False,
+        "active_session_summary": False,
+        "vault_index_first": False,
+        "backlink_expansion": False,
+        "suggested_actions": False,
+    }
+    flags.update(overrides)
+    return {
+        "retrieval": {
+            "context_token_budget": 6000,
+            "max_tool_calls_per_turn": 8,
+            "max_files": 5,
+        },
+        "context_engineering": flags,
+        "sync": {"conflict_auto_merge": False},
+    }
+
+
+# -- ContextBundle exposes a flags dict ----------------------------------
+
+
+def test_bundle_exposes_flags_dict_for_audit(tmp_path: Path) -> None:
+    """The bundle records which Booleans were ON for downstream audit."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle = gather_context(
+        query="consciousness",
+        config=_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    assert isinstance(bundle, ContextBundle)
+    assert isinstance(bundle.flags, dict)
+    assert bundle.flags["tiered_retrieval"] is True
+    assert bundle.flags["per_domain_shaping"] is True
+    assert bundle.flags["vault_index_first"] is True
+
+
+# -- 1. tiered_retrieval -------------------------------------------------
+
+
+def test_tiered_retrieval_off_skips_index_and_session(tmp_path: Path) -> None:
+    """When tiered_retrieval=false, no INDEX/session content is preloaded."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle_off = gather_context(
+        query="consciousness",
+        config=_all_off_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    sources = [s.source for s in bundle_off.snippets]
+    assert not any(s.endswith("INDEX.md") for s in sources)
+    assert not any(s.endswith("active_session.md") for s in sources)
+
+
+def test_tiered_retrieval_on_preloads_index_and_session(tmp_path: Path) -> None:
+    """When tiered_retrieval=true, INDEX + session are part of the bundle."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle_on = gather_context(
+        query="consciousness",
+        config=_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    sources = [s.source for s in bundle_on.snippets]
+    assert any(s.endswith("INDEX.md") for s in sources)
+    assert any(s.endswith("active_session.md") for s in sources)
+
+
+# -- 2. per_domain_shaping -----------------------------------------------
+
+
+def test_per_domain_shaping_on_registers_query_tools(tmp_path: Path) -> None:
+    """When per_domain_shaping=true, query_finance/inventory/fitness are exposed."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle = gather_context(
+        query="how much did I spend on coffee?",
+        config=_config(),
+        vault_root=vault_root,
+        domain="finance",
+    )
+
+    palette = set(bundle.tool_palette)
+    assert "query_finance" in palette
+    assert "query_inventory" in palette
+    assert "query_fitness" in palette
+
+
+def test_per_domain_shaping_off_excludes_query_tools(tmp_path: Path) -> None:
+    """When per_domain_shaping=false, query_* tools are NOT registered."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle = gather_context(
+        query="how much did I spend on coffee?",
+        config=_all_off_config(),
+        vault_root=vault_root,
+        domain="finance",
+    )
+
+    palette = set(bundle.tool_palette)
+    for name in ("query_finance", "query_inventory", "query_fitness"):
+        assert name not in palette, f"{name} should be absent when per_domain_shaping=false"
+
+
+# -- 3. recency_weighting ------------------------------------------------
+
+
+def test_recency_weighting_on_orders_matches_recent_first(tmp_path: Path) -> None:
+    """ON: filename-date desc — 2026-04-20 before 2026-04-01."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(
+        vault_root,
+        journal_files=[
+            ("2026-04-01-conscious-old.md", "consciousness consciousness"),
+            ("2026-04-20-conscious-new.md", "consciousness consciousness"),
+        ],
+    )
+
+    bundle = gather_context(
+        query="consciousness",
+        config=_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    matched = [s.source for s in bundle.snippets if "/journal/" in s.source]
+    assert matched, "expected at least one journal match"
+    # Newest first.
+    assert matched[0].endswith("2026-04-20-conscious-new.md")
+    # And the older one comes after.
+    older_idx = next(i for i, s in enumerate(matched) if s.endswith("2026-04-01-conscious-old.md"))
+    newer_idx = next(i for i, s in enumerate(matched) if s.endswith("2026-04-20-conscious-new.md"))
+    assert newer_idx < older_idx
+
+
+def test_recency_weighting_off_orders_matches_alphabetically(tmp_path: Path) -> None:
+    """OFF: alphabetical ascending — 2026-04-01 before 2026-04-20."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(
+        vault_root,
+        journal_files=[
+            ("2026-04-01-conscious-old.md", "consciousness consciousness"),
+            ("2026-04-20-conscious-new.md", "consciousness consciousness"),
+        ],
+    )
+
+    bundle = gather_context(
+        query="consciousness",
+        config=_all_off_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    matched = [s.source for s in bundle.snippets if "/journal/" in s.source]
+    older_idx = next(i for i, s in enumerate(matched) if s.endswith("2026-04-01-conscious-old.md"))
+    newer_idx = next(i for i, s in enumerate(matched) if s.endswith("2026-04-20-conscious-new.md"))
+    assert older_idx < newer_idx
+
+
+def test_recency_weighting_on_appends_recency_hint_to_system_prompt(tmp_path: Path) -> None:
+    """The bundle's ``system_prompt_suffix`` carries a recency directive when ON."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle_on = gather_context(
+        query="consciousness",
+        config=_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    assert "recent" in bundle_on.system_prompt_suffix.lower()
+
+
+def test_recency_weighting_off_omits_recency_hint(tmp_path: Path) -> None:
+    """The bundle's ``system_prompt_suffix`` omits the recency directive when OFF."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle_off = gather_context(
+        query="consciousness",
+        config=_all_off_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    assert "recent" not in bundle_off.system_prompt_suffix.lower()
+
+
+# -- 4. active_session_summary -------------------------------------------
+
+
+def test_active_session_summary_on_includes_session_snippet(tmp_path: Path) -> None:
+    """ON: vault/_index/active_session.md content is present in snippets."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle = gather_context(
+        query="consciousness",
+        config=_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    sources = [s.source for s in bundle.snippets]
+    assert any(s.endswith("active_session.md") for s in sources)
+
+
+def test_active_session_summary_off_omits_session_snippet(tmp_path: Path) -> None:
+    """OFF: session snippet is absent even when the file exists."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    # Tiered ON so INDEX still loads, only session OFF.
+    cfg = _config(active_session_summary=False)
+    bundle = gather_context(
+        query="consciousness",
+        config=cfg,
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    sources = [s.source for s in bundle.snippets]
+    assert not any(s.endswith("active_session.md") for s in sources)
+
+
+# -- 5. vault_index_first ------------------------------------------------
+
+
+def test_vault_index_first_on_includes_index_snippet(tmp_path: Path) -> None:
+    """ON: INDEX.md is preloaded as the first snippet."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle = gather_context(
+        query="consciousness",
+        config=_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    sources = [s.source for s in bundle.snippets]
+    assert any(s.endswith("INDEX.md") for s in sources)
+
+
+def test_vault_index_first_off_omits_index_snippet(tmp_path: Path) -> None:
+    """OFF: INDEX.md is not preloaded; grep is still allowed."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    cfg = _config(vault_index_first=False)
+    bundle = gather_context(
+        query="consciousness",
+        config=cfg,
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    sources = [s.source for s in bundle.snippets]
+    assert not any(s.endswith("INDEX.md") for s in sources)
+    # Grep still works — at least one journal match should be present.
+    assert any("/journal/" in s for s in sources)
+
+
+# -- 6. backlink_expansion -----------------------------------------------
+
+
+def test_backlink_expansion_on_registers_read_backlinks_tool(tmp_path: Path) -> None:
+    """ON: ``read_backlinks`` is in the tool palette."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle = gather_context(
+        query="consciousness",
+        config=_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    assert "read_backlinks" in bundle.tool_palette
+
+
+def test_backlink_expansion_off_omits_read_backlinks_tool(tmp_path: Path) -> None:
+    """OFF: ``read_backlinks`` is NOT in the tool palette."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle = gather_context(
+        query="consciousness",
+        config=_all_off_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    assert "read_backlinks" not in bundle.tool_palette
+
+
+# -- 7. suggested_actions ------------------------------------------------
+
+
+def test_suggested_actions_flag_propagates_into_bundle(tmp_path: Path) -> None:
+    """The bundle's ``flags`` dict surfaces ``suggested_actions`` for digests."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle_on = gather_context(
+        query="consciousness",
+        config=_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+    bundle_off = gather_context(
+        query="consciousness",
+        config=_all_off_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    assert bundle_on.flags["suggested_actions"] is True
+    assert bundle_off.flags["suggested_actions"] is False
+
+
+# -- 8. conflict_auto_merge ----------------------------------------------
+
+
+def test_conflict_auto_merge_flag_propagates_into_bundle(tmp_path: Path) -> None:
+    """The bundle's ``flags`` dict carries ``conflict_auto_merge`` for completeness."""
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle_on = gather_context(
+        query="consciousness",
+        config=_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+    bundle_off = gather_context(
+        query="consciousness",
+        config=_all_off_config(),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    assert bundle_on.flags["conflict_auto_merge"] is True
+    assert bundle_off.flags["conflict_auto_merge"] is False
+
+
+# -- portfolio assertion: default vs baseline ---------------------------
+
+
+def _project_root() -> Path:
+    """Walk up to the personal-assistant project root."""
+    here = Path(__file__).resolve()
+    return here.parent.parent
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def test_default_yaml_vs_baseline_yaml_produce_different_bundles(
+    tmp_path: Path,
+) -> None:
+    """Load real configs side-by-side; bundles must diverge end-to-end.
+
+    This is the load-bearing claim for the eval. Same vault, same query,
+    same retrieval entry point — only the eight-Boolean config differs.
+    """
+    project_root = _project_root()
+    default_cfg = _load_yaml(project_root / "configs" / "default.yaml")
+    baseline_cfg = _load_yaml(project_root / "configs" / "baseline.yaml")
+
+    vault_root = tmp_path / "vault"
+    _seed_vault(vault_root)
+
+    bundle_default = gather_context(
+        query="consciousness",
+        config=default_cfg,
+        vault_root=vault_root,
+        domain="journal",
+    )
+    bundle_baseline = gather_context(
+        query="consciousness",
+        config=baseline_cfg,
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    # The bundles must be observably different.
+    assert bundle_default != bundle_baseline
+
+    # The default tool palette is a strict superset of baseline's.
+    palette_default = set(bundle_default.tool_palette)
+    palette_baseline = set(bundle_baseline.tool_palette)
+    assert palette_default >= palette_baseline
+    assert palette_default - palette_baseline, (
+        "default must register strictly more tools than baseline"
+    )
+
+    # Concrete signals that distinguish default from baseline:
+    default_sources = {s.source for s in bundle_default.snippets}
+    baseline_sources = {s.source for s in bundle_baseline.snippets}
+    assert any(s.endswith("INDEX.md") for s in default_sources)
+    assert not any(s.endswith("INDEX.md") for s in baseline_sources)
+    assert "query_finance" in palette_default
+    assert "query_finance" not in palette_baseline
+    assert "read_backlinks" in palette_default
+    assert "read_backlinks" not in palette_baseline

--- a/tests/test_retrieval_budget.py
+++ b/tests/test_retrieval_budget.py
@@ -1,0 +1,163 @@
+"""Issue #10 — context_token_budget + max_tool_calls_per_turn caps.
+
+The retrieval engine MUST respect both caps from ``configs/default.yaml``:
+``context_token_budget`` (char-proxy estimate) and ``max_tool_calls_per_turn``.
+Bundles must stay under budget on large vaults; tool palette assembly must
+not exceed the call cap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kernel.retrieval import gather_context
+
+
+def _seed_journal_n(vault_root: Path, n: int, body: str) -> None:
+    journal = vault_root / "journal"
+    journal.mkdir(parents=True, exist_ok=True)
+    for i in range(n):
+        path = journal / f"2026-04-{i+1:02d}-conscious-{i}.md"
+        path.write_text(body, encoding="utf-8")
+
+
+def _config(*, budget: int, max_files: int = 20, max_tool_calls: int = 8) -> dict:
+    return {
+        "retrieval": {
+            "context_token_budget": budget,
+            "max_files": max_files,
+            "max_tool_calls_per_turn": max_tool_calls,
+        },
+        "context_engineering": {
+            "tiered_retrieval": True,
+            "per_domain_shaping": True,
+            "recency_weighting": True,
+            "active_session_summary": True,
+            "vault_index_first": True,
+            "backlink_expansion": True,
+            "suggested_actions": True,
+        },
+    }
+
+
+# -- token budget --------------------------------------------------------
+
+
+def test_bundle_stays_under_token_budget_on_large_vault(tmp_path: Path) -> None:
+    """A vault with 30 large files + tiny budget yields a budget-respecting bundle.
+
+    The char-proxy is 4 chars/token so the bundle's total snippet length
+    must fit within ``budget * 4`` characters.
+    """
+    vault_root = tmp_path / "vault"
+    big_body = "consciousness " * 500  # ~7000 chars per file
+    _seed_journal_n(vault_root, 30, big_body)
+
+    bundle = gather_context(
+        query="consciousness",
+        config=_config(budget=400, max_files=30),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    total_chars = sum(len(s.text) for s in bundle.snippets)
+    # 4-char-per-token proxy.
+    assert total_chars <= 400 * 4
+
+
+def test_bundle_tokens_estimate_matches_snippet_chars(tmp_path: Path) -> None:
+    """The bundle's ``tokens_estimate`` matches its char-proxy of snippets."""
+    vault_root = tmp_path / "vault"
+    _seed_journal_n(vault_root, 3, "consciousness " * 100)
+
+    bundle = gather_context(
+        query="consciousness",
+        config=_config(budget=2000),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    expected = sum(len(s.text) for s in bundle.snippets) // 4
+    assert bundle.tokens_estimate == expected
+
+
+def test_zero_budget_yields_empty_or_truncated_bundle(tmp_path: Path) -> None:
+    """A budget of 0 still returns a bundle (paths recorded, snippets minimal)."""
+    vault_root = tmp_path / "vault"
+    _seed_journal_n(vault_root, 2, "consciousness " * 50)
+
+    bundle = gather_context(
+        query="consciousness",
+        config=_config(budget=0),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    # Implementation choice: budget=0 sentinels treat budget as "no cap"
+    # (matches issue #3's current behavior where _budget_chars is 0).
+    # The caller can still detect this via tokens_estimate.
+    assert bundle.tokens_estimate >= 0
+
+
+# -- max_tool_calls_per_turn --------------------------------------------
+
+
+def test_max_tool_calls_propagated_to_bundle(tmp_path: Path) -> None:
+    """The bundle exposes ``max_tool_calls`` so the agent prompt can quote it."""
+    vault_root = tmp_path / "vault"
+    _seed_journal_n(vault_root, 2, "consciousness")
+
+    bundle = gather_context(
+        query="consciousness",
+        config=_config(budget=6000, max_tool_calls=8),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    assert bundle.max_tool_calls == 8
+
+
+def test_max_tool_calls_default_when_unspecified(tmp_path: Path) -> None:
+    """An absent ``max_tool_calls_per_turn`` falls back to the configured default."""
+    vault_root = tmp_path / "vault"
+    _seed_journal_n(vault_root, 1, "consciousness")
+
+    cfg: dict[str, Any] = {
+        "context_engineering": {
+            "tiered_retrieval": True,
+            "per_domain_shaping": False,
+            "recency_weighting": False,
+            "active_session_summary": False,
+            "vault_index_first": False,
+            "backlink_expansion": False,
+            "suggested_actions": False,
+        },
+        "retrieval": {"context_token_budget": 1000},
+    }
+    bundle = gather_context(
+        query="consciousness",
+        config=cfg,
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    # Default from configs/default.yaml is 8.
+    assert bundle.max_tool_calls == 8
+
+
+def test_max_tool_calls_clamps_below_one(tmp_path: Path) -> None:
+    """A pathological ``max_tool_calls_per_turn=0`` is clamped to >=1."""
+    vault_root = tmp_path / "vault"
+    _seed_journal_n(vault_root, 1, "consciousness")
+
+    bundle = gather_context(
+        query="consciousness",
+        config=_config(budget=6000, max_tool_calls=0),
+        vault_root=vault_root,
+        domain="journal",
+    )
+
+    assert bundle.max_tool_calls >= 1

--- a/tests/test_retrieval_tools.py
+++ b/tests/test_retrieval_tools.py
@@ -1,0 +1,221 @@
+"""Issue #10 — ``expand_keywords`` and ``read_backlinks`` tool callables.
+
+These two helpers are exposed in the agent tool palette under engineered
+config (per ``configs/default.yaml``); the tests exercise their semantics
+in isolation, with a mocked LLM invoker so the suite never shells out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import pytest
+
+from kernel.claude_runner import ClaudeResponse
+from kernel.retrieval import expand_keywords, read_backlinks
+
+
+# -- helpers -------------------------------------------------------------
+
+
+def _stub_invoker(text: str) -> Callable[..., ClaudeResponse]:
+    """Build a deterministic LLM invoker that returns ``text`` once."""
+
+    def _invoke(prompt, *, system_prompt: Optional[str] = None):
+        return ClaudeResponse(
+            text=text,
+            tokens_in=1,
+            tokens_out=1,
+            raw={"prompt": prompt, "system_prompt": system_prompt},
+        )
+
+    return _invoke
+
+
+def _failing_invoker(*_args: Any, **_kwargs: Any) -> ClaudeResponse:
+    raise RuntimeError("LLM unreachable")
+
+
+# -- expand_keywords -----------------------------------------------------
+
+
+def test_expand_keywords_returns_seed_first(tmp_path: Path) -> None:
+    """Seed term is always the first element of the returned list."""
+    invoker = _stub_invoker("self-awareness, qualia, mind, cognition")
+
+    out = expand_keywords("consciousness", invoker=invoker)
+
+    assert out, "expected non-empty expansion"
+    assert out[0] == "consciousness"
+
+
+def test_expand_keywords_returns_synonyms(tmp_path: Path) -> None:
+    """The LLM-supplied synonyms are appended after the seed."""
+    invoker = _stub_invoker("self-awareness, qualia, subjective experience")
+
+    out = expand_keywords("consciousness", invoker=invoker)
+
+    assert "self-awareness" in out
+    assert "qualia" in out
+    assert "subjective experience" in out
+
+
+def test_expand_keywords_lowercases_and_dedupes(tmp_path: Path) -> None:
+    """Returned terms are lowercased; duplicates are dropped."""
+    invoker = _stub_invoker("Self-Awareness, qualia, QUALIA, Self-Awareness")
+
+    out = expand_keywords("Consciousness", invoker=invoker)
+
+    # All lowercase; no duplicates.
+    assert all(term == term.lower() for term in out)
+    assert len(out) == len(set(out))
+
+
+def test_expand_keywords_empty_seed_returns_empty(tmp_path: Path) -> None:
+    """An empty seed query returns an empty list — defensive fast-path."""
+    out = expand_keywords("   ", invoker=_stub_invoker("a, b, c"))
+    assert out == []
+
+
+def test_expand_keywords_falls_back_when_llm_fails(tmp_path: Path) -> None:
+    """If the invoker raises, expand_keywords degrades to seed only."""
+    out = expand_keywords("consciousness", invoker=_failing_invoker)
+    assert out == ["consciousness"]
+
+
+def test_expand_keywords_respects_max_terms_cap(tmp_path: Path) -> None:
+    """The ``max_terms`` cap is honored even with a chatty LLM."""
+    invoker = _stub_invoker("a, b, c, d, e, f, g, h, i, j, k, l")
+
+    out = expand_keywords("consciousness", invoker=invoker, max_terms=4)
+
+    assert len(out) <= 4
+    # Seed still comes first.
+    assert out[0] == "consciousness"
+
+
+# -- read_backlinks -------------------------------------------------------
+
+
+def _seed_wikilinked_vault(vault_root: Path) -> dict[str, Path]:
+    """Build a tiny graph: A -> B, B -> C, isolated D."""
+    journal = vault_root / "journal"
+    journal.mkdir(parents=True, exist_ok=True)
+    a = journal / "A.md"
+    b = journal / "B.md"
+    c = journal / "C.md"
+    d = journal / "D.md"
+    a.write_text("Today I thought about [[B]] and a tangent.\n", encoding="utf-8")
+    b.write_text("Following up — also [[C]] is relevant.\n", encoding="utf-8")
+    c.write_text("End of the chain. No outgoing links here.\n", encoding="utf-8")
+    d.write_text("An isolated note with no links.\n", encoding="utf-8")
+    return {"A": a, "B": b, "C": c, "D": d}
+
+
+def test_read_backlinks_one_hop_returns_direct_neighbors(tmp_path: Path) -> None:
+    """A 1-hop walk from A reaches B but not C."""
+    vault_root = tmp_path / "vault"
+    seeded = _seed_wikilinked_vault(vault_root)
+
+    out = read_backlinks(seeded["A"], vault_root=vault_root, max_hops=1)
+
+    out_resolved = {p.resolve() for p in out}
+    assert seeded["B"].resolve() in out_resolved
+    assert seeded["C"].resolve() not in out_resolved
+
+
+def test_read_backlinks_two_hops_returns_transitive_neighbors(
+    tmp_path: Path,
+) -> None:
+    """A 2-hop walk reaches both B (direct) and C (via B)."""
+    vault_root = tmp_path / "vault"
+    seeded = _seed_wikilinked_vault(vault_root)
+
+    out = read_backlinks(seeded["A"], vault_root=vault_root, max_hops=2)
+
+    out_resolved = {p.resolve() for p in out}
+    assert seeded["B"].resolve() in out_resolved
+    assert seeded["C"].resolve() in out_resolved
+
+
+def test_read_backlinks_zero_hops_returns_empty(tmp_path: Path) -> None:
+    """``max_hops=0`` returns an empty list — no walk happens."""
+    vault_root = tmp_path / "vault"
+    seeded = _seed_wikilinked_vault(vault_root)
+
+    out = read_backlinks(seeded["A"], vault_root=vault_root, max_hops=0)
+    assert out == []
+
+
+def test_read_backlinks_never_includes_seed(tmp_path: Path) -> None:
+    """The seed file itself is never returned, even when it links back."""
+    vault_root = tmp_path / "vault"
+    seeded = _seed_wikilinked_vault(vault_root)
+    # Add a back-edge from B to A.
+    seeded["B"].write_text(
+        "Following up — also [[C]] and [[A]].\n", encoding="utf-8"
+    )
+
+    out = read_backlinks(seeded["A"], vault_root=vault_root, max_hops=2)
+    out_resolved = {p.resolve() for p in out}
+
+    assert seeded["A"].resolve() not in out_resolved
+
+
+def test_read_backlinks_dedupes_repeated_links(tmp_path: Path) -> None:
+    """A target reached twice via different paths only appears once."""
+    vault_root = tmp_path / "vault"
+    seeded = _seed_wikilinked_vault(vault_root)
+    # Make A link to B twice + once to C, so BFS sees C directly + via B.
+    seeded["A"].write_text(
+        "[[B]] and [[B]] again, plus [[C]].\n", encoding="utf-8"
+    )
+
+    out = read_backlinks(seeded["A"], vault_root=vault_root, max_hops=2)
+    paths_str = [str(p.resolve()) for p in out]
+
+    assert len(paths_str) == len(set(paths_str))
+
+
+def test_read_backlinks_handles_missing_targets_gracefully(
+    tmp_path: Path,
+) -> None:
+    """A wikilink to a non-existent file is silently skipped."""
+    vault_root = tmp_path / "vault"
+    journal = vault_root / "journal"
+    journal.mkdir(parents=True, exist_ok=True)
+    seed = journal / "seed.md"
+    seed.write_text("Linking to [[nonexistent-target]] only.\n", encoding="utf-8")
+
+    out = read_backlinks(seed, vault_root=vault_root, max_hops=1)
+    assert out == []
+
+
+def test_read_backlinks_returns_empty_when_seed_missing(tmp_path: Path) -> None:
+    """A missing seed path yields an empty list, not an error."""
+    out = read_backlinks(
+        tmp_path / "no-such-file.md",
+        vault_root=tmp_path,
+        max_hops=2,
+    )
+    assert out == []
+
+
+def test_read_backlinks_max_hops_is_a_strict_cap(tmp_path: Path) -> None:
+    """Past ``max_hops``, the walk stops — never hits hop+1 neighbors."""
+    vault_root = tmp_path / "vault"
+    journal = vault_root / "journal"
+    journal.mkdir(parents=True, exist_ok=True)
+    # Build a 4-deep chain: A -> B -> C -> D.
+    (journal / "A.md").write_text("[[B]]\n", encoding="utf-8")
+    (journal / "B.md").write_text("[[C]]\n", encoding="utf-8")
+    (journal / "C.md").write_text("[[D]]\n", encoding="utf-8")
+    (journal / "D.md").write_text("end\n", encoding="utf-8")
+
+    out = read_backlinks(journal / "A.md", vault_root=vault_root, max_hops=2)
+    names = {p.name for p in out}
+
+    assert "B.md" in names
+    assert "C.md" in names
+    assert "D.md" not in names


### PR DESCRIPTION
## Summary

Closes #10. Extends `kernel/retrieval.py` from issue #3's minimal tier order into the full eight-Boolean config-driven contract. Same query under `configs/default.yaml` (all ON) vs `configs/baseline.yaml` (all OFF) now produces measurably different `ContextBundle` outputs — the linchpin for the eval claim.

- Each of the eight Booleans (`tiered_retrieval`, `per_domain_shaping`, `recency_weighting`, `active_session_summary`, `vault_index_first`, `backlink_expansion`, `suggested_actions`, `conflict_auto_merge`) controls one observable difference in the bundle.
- `ContextBundle` gains `flags`, `tool_palette`, `system_prompt_suffix`, `tokens_estimate`, `max_tool_calls`.
- Adds `expand_keywords(seed, invoker)` and `read_backlinks(file, vault_root, max_hops)` tool callables.
- Orchestrator's `journal.query` handler records `tokens_in_context_bundle` and `flags` on the read audit entry.
- Backward compatible: defaults-when-flag-missing = True so existing tests (test_retrieval.py + test_orchestrator_journal_query.py) keep passing.

## Test plan

- [x] `pytest -q` — 280 passed (238 prior + 42 new)
- [x] `tests/test_retrieval_booleans.py` (18) — one test per Boolean ON vs OFF; load-bearing portfolio assertion loading real `configs/default.yaml` vs `configs/baseline.yaml` against same fixture vault
- [x] `tests/test_retrieval_budget.py` (6) — context_token_budget cap; max_tool_calls clamping
- [x] `tests/test_retrieval_tools.py` (14) — `expand_keywords` (mock LLM) + `read_backlinks` (BFS, dedupe, max_hops cap, missing targets)
- [x] `tests/test_orchestrator_retrieval_audit.py` (4) — integration: default vs baseline audit entries reflect toggle state
- [x] All issue-#3 tests still green (no regression on the journal-query path)