### PR TITLE
feat(infra): launchd plists for digests, reminders, conflict watcher, bot keep-alive

### DIFF
--- a/infra/launchd/README.md
+++ b/infra/launchd/README.md
@@ -1,0 +1,148 @@
+# launchd plists — Mac mini scheduling
+
+This directory holds the five launchd plists that schedule the proactive
+loops on the Mac mini host:
+
+| Plist | Cadence | What it runs |
+|---|---|---|
+| `com.jasonchi.pa.daily-digest.plist`     | 08:00 daily          | `python -m kernel.proactive --task daily-digest` |
+| `com.jasonchi.pa.weekly-digest.plist`    | Sunday 18:00         | `python -m kernel.proactive --task weekly-digest` |
+| `com.jasonchi.pa.reminder-check.plist`   | Every 5 min (300s)   | `python -m kernel.proactive --task check-reminders` |
+| `com.jasonchi.pa.conflict-watcher.plist` | Every 1 min (60s)    | `python -m kernel.conflict_watcher --run-once` |
+| `com.jasonchi.pa.bot.plist`              | Long-running daemon  | `python -m kernel.telegram_bridge` (KeepAlive=true) |
+
+Cadences mirror `configs/default.yaml`'s `proactive.*` and
+`sync.conflict_watcher_interval_min`. Don't drift them.
+
+## Why `--run-once` for the conflict watcher?
+
+`kernel.conflict_watcher` exposes both `run_once()` and `run_loop()`.
+launchd handles cadence itself, so we want each invocation to perform a
+single scan and exit. `run_loop()` is reserved for foreground debugging
+on a developer laptop where launchd isn't in the picture.
+
+## Install
+
+The plists ship with two placeholder tokens:
+
+- `__PROJECT_ROOT__` — absolute path to your local clone (no trailing slash)
+- `__TELEGRAM_BOT_TOKEN__` — the bot token from `@BotFather`
+
+Substitute and copy with this snippet (run from the repo root):
+
+```bash
+PROJECT_ROOT="$(pwd)"
+TELEGRAM_BOT_TOKEN="<paste-real-token>"
+
+# Render every plist into ~/Library/LaunchAgents
+mkdir -p "$HOME/Library/LaunchAgents"
+for plist in infra/launchd/com.jasonchi.pa.*.plist; do
+  out="$HOME/Library/LaunchAgents/$(basename "$plist")"
+  sed \
+    -e "s|__PROJECT_ROOT__|$PROJECT_ROOT|g" \
+    -e "s|__TELEGRAM_BOT_TOKEN__|$TELEGRAM_BOT_TOKEN|g" \
+    "$plist" > "$out"
+done
+```
+
+Then load each plist (`-w` makes the registration persist across reboots):
+
+```bash
+for plist in "$HOME/Library/LaunchAgents/com.jasonchi.pa."*.plist; do
+  launchctl load -w "$plist"
+done
+```
+
+## Verify
+
+```bash
+launchctl list | grep com.jasonchi.pa
+```
+
+You should see all five labels. Schedule-driven jobs report `-` in the
+PID column until they next fire; the bot reports a live PID.
+
+Audit log lines confirm the jobs are firing:
+
+```bash
+ls -la vault/_audit/
+tail -f vault/_audit/$(date +%F).jsonl
+```
+
+## Inspect logs
+
+stdout and stderr are routed per-plist into this directory:
+
+```bash
+tail -f infra/launchd/bot.log
+tail -f infra/launchd/conflict-watcher.log
+tail -f infra/launchd/daily-digest.log
+tail -f infra/launchd/weekly-digest.log
+tail -f infra/launchd/reminder-check.log
+```
+
+Each plist also writes a `*.err.log` companion for stderr.
+
+## Unload (stop the jobs)
+
+```bash
+for plist in "$HOME/Library/LaunchAgents/com.jasonchi.pa."*.plist; do
+  launchctl unload -w "$plist"
+done
+```
+
+To uninstall completely, delete the rendered plists from
+`~/Library/LaunchAgents/` after unloading.
+
+## Reload after editing a plist
+
+```bash
+launchctl unload "$HOME/Library/LaunchAgents/com.jasonchi.pa.bot.plist"
+# (re-render via the sed snippet above)
+launchctl load -w "$HOME/Library/LaunchAgents/com.jasonchi.pa.bot.plist"
+```
+
+## Caveats
+
+### macOS Full Disk Access for the vault
+
+The vault lives in `~/Library/CloudStorage/GoogleDrive-.../...`, which
+sits behind macOS's app-sandbox protections. Grant the Python interpreter
+(or the Terminal you used to install) **Full Disk Access** in
+`System Settings → Privacy & Security → Full Disk Access`, otherwise
+launchd-spawned Python will see permission errors when reading or writing
+vault files.
+
+### `python3.12` discovery
+
+The plists invoke `/usr/bin/env python3.12`. If your Mac mini has Python
+under a different name (e.g., Homebrew installs as `python3` only, or
+you use `pyenv`), either:
+
+- symlink: `sudo ln -s "$(which python3)" /usr/local/bin/python3.12`
+- or edit the plist's `ProgramArguments` to call your interpreter directly.
+
+The `PATH` value inside `EnvironmentVariables` is intentionally minimal
+(`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`) — launchd processes
+do **not** inherit your shell's `PATH`. Add `~/.pyenv/shims` here if you
+manage Python with pyenv.
+
+### Single-instance lock
+
+`kernel/orchestrator.py` acquires a flock on `/tmp/personal-assistant.lock`.
+If the bot plist's KeepAlive restart races a still-cleanly-shutting-down
+PID, the new process refuses to start — which is the intended safety
+behaviour. launchd will retry after `ThrottleInterval` (10s).
+
+### Time zones
+
+launchd's `StartCalendarInterval` uses the system's local time. Confirm
+with `sudo systemsetup -gettimezone`. The default config assumes
+`America/Vancouver`; if you relocate the mini, both the system tz and
+the plists' wall-clock interpretations will change with it.
+
+### Drive sync vs. immediate writes
+
+Daily/weekly digests and reminder fires write to the vault. Drive Desktop
+sync is best-effort; expect a few seconds of replication lag before
+edits show up on phone Obsidian.

--- a/infra/launchd/com.jasonchi.pa.bot.plist
+++ b/infra/launchd/com.jasonchi.pa.bot.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.jasonchi.pa.bot</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>python3.12</string>
+        <string>-m</string>
+        <string>kernel.telegram_bridge</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>WorkingDirectory</key>
+    <string>__PROJECT_ROOT__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>TELEGRAM_BOT_TOKEN</key>
+        <string>__TELEGRAM_BOT_TOKEN__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__PROJECT_ROOT__/infra/launchd/bot.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__PROJECT_ROOT__/infra/launchd/bot.err.log</string>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/infra/launchd/com.jasonchi.pa.conflict-watcher.plist
+++ b/infra/launchd/com.jasonchi.pa.conflict-watcher.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.jasonchi.pa.conflict-watcher</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>python3.12</string>
+        <string>-m</string>
+        <string>kernel.conflict_watcher</string>
+        <string>--run-once</string>
+        <string>--config</string>
+        <string>configs/default.yaml</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>60</integer>
+
+    <key>WorkingDirectory</key>
+    <string>__PROJECT_ROOT__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>TELEGRAM_BOT_TOKEN</key>
+        <string>__TELEGRAM_BOT_TOKEN__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__PROJECT_ROOT__/infra/launchd/conflict-watcher.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__PROJECT_ROOT__/infra/launchd/conflict-watcher.err.log</string>
+
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/infra/launchd/com.jasonchi.pa.daily-digest.plist
+++ b/infra/launchd/com.jasonchi.pa.daily-digest.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.jasonchi.pa.daily-digest</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>python3.12</string>
+        <string>-m</string>
+        <string>kernel.proactive</string>
+        <string>--task</string>
+        <string>daily-digest</string>
+        <string>--config</string>
+        <string>configs/default.yaml</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>8</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>__PROJECT_ROOT__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>TELEGRAM_BOT_TOKEN</key>
+        <string>__TELEGRAM_BOT_TOKEN__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__PROJECT_ROOT__/infra/launchd/daily-digest.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__PROJECT_ROOT__/infra/launchd/daily-digest.err.log</string>
+
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/infra/launchd/com.jasonchi.pa.reminder-check.plist
+++ b/infra/launchd/com.jasonchi.pa.reminder-check.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.jasonchi.pa.reminder-check</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>python3.12</string>
+        <string>-m</string>
+        <string>kernel.proactive</string>
+        <string>--task</string>
+        <string>check-reminders</string>
+        <string>--config</string>
+        <string>configs/default.yaml</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>WorkingDirectory</key>
+    <string>__PROJECT_ROOT__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>TELEGRAM_BOT_TOKEN</key>
+        <string>__TELEGRAM_BOT_TOKEN__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__PROJECT_ROOT__/infra/launchd/reminder-check.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__PROJECT_ROOT__/infra/launchd/reminder-check.err.log</string>
+
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/infra/launchd/com.jasonchi.pa.weekly-digest.plist
+++ b/infra/launchd/com.jasonchi.pa.weekly-digest.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.jasonchi.pa.weekly-digest</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>python3.12</string>
+        <string>-m</string>
+        <string>kernel.proactive</string>
+        <string>--task</string>
+        <string>weekly-digest</string>
+        <string>--config</string>
+        <string>configs/default.yaml</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>18</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>__PROJECT_ROOT__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>TELEGRAM_BOT_TOKEN</key>
+        <string>__TELEGRAM_BOT_TOKEN__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__PROJECT_ROOT__/infra/launchd/weekly-digest.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__PROJECT_ROOT__/infra/launchd/weekly-digest.err.log</string>
+
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/kernel/conflict_watcher.py
+++ b/kernel/conflict_watcher.py
@@ -42,6 +42,7 @@ __all__ = [
     "ConflictWatcher",
     "MergerFn",
     "NotifierFn",
+    "main",
 ]
 
 
@@ -330,3 +331,118 @@ class ConflictWatcher:
             self._audit_writer(entry, audit_root=self._audit_root)
         except Exception:  # noqa: BLE001
             logger.exception("audit write failed for %s", conflict_path)
+
+
+# ---------------------------------------------------------------------------
+# CLI — invoked by the launchd plist every minute.
+# ---------------------------------------------------------------------------
+
+
+def _noop_merger(*, canonical_text: str, conflict_text: str, diff: str) -> str:
+    """Default CLI merger — returns canonical unchanged.
+
+    Production CLI invocations from launchd default to staging-only
+    (``--no-auto-merge``), so the merger is never consulted. We still
+    install a non-raising default for safety: if a future caller flips
+    auto-merge on without providing an LLM-backed merger, we degrade to
+    "preserve canonical, drop conflict" rather than crash.
+    """
+    return canonical_text
+
+
+def _stderr_notifier(message: str) -> None:
+    """Default CLI notifier — log-only.
+
+    The bot polling loop owns Telegram delivery. The conflict-watcher
+    CLI runs as a one-shot subprocess with no Telegram session, so it
+    just writes to stderr; the launchd plist routes that to a log file
+    (``infra/launchd/conflict-watcher.err.log``).
+    """
+    import sys as _sys
+
+    _sys.stderr.write(f"conflict-watcher: {message}\n")
+
+
+def _build_cli_parser() -> "argparse.ArgumentParser":
+    """argparse spec — ``python -m kernel.conflict_watcher --run-once``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m kernel.conflict_watcher",
+        description="Single-shot Drive-conflict scan (launchd cadence: every 1 min).",
+    )
+    parser.add_argument(
+        "--run-once",
+        action="store_true",
+        help="Perform a single scan and exit (the launchd-friendly mode).",
+    )
+    parser.add_argument(
+        "--vault-root",
+        default="vault",
+        help="Vault root on disk (default: ./vault).",
+    )
+    parser.add_argument(
+        "--audit-root",
+        default="vault/_audit",
+        help="Audit-log root (default: ./vault/_audit).",
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to a YAML config file (e.g., configs/default.yaml).",
+    )
+    return parser
+
+
+def _resolve_auto_merge(config_path: Optional[str]) -> tuple[bool, str]:
+    """Read ``sync.conflict_auto_merge`` and pick a config label."""
+    if not config_path:
+        return False, "default"
+    path = Path(config_path)
+    if not path.exists():
+        return False, "default"
+    try:
+        import yaml  # local import; yaml is a runtime dep already
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception:  # noqa: BLE001
+        return False, "default"
+    sync = data.get("sync") or {} if isinstance(data, dict) else {}
+    auto_merge = bool(sync.get("conflict_auto_merge", False)) if isinstance(sync, dict) else False
+    label = "baseline" if "baseline" in path.name else "default"
+    return auto_merge, label
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entrypoint. Returns process exit code.
+
+    The launchd plist invokes this every minute with ``--run-once``.
+    Each invocation constructs a fresh ``ConflictWatcher`` and performs
+    exactly one scan. ``run_loop`` is reserved for foreground debug.
+    """
+    parser = _build_cli_parser()
+    args = parser.parse_args(argv)
+
+    auto_merge, config_label = _resolve_auto_merge(args.config)
+
+    watcher = ConflictWatcher(
+        vault_root=args.vault_root,
+        audit_root=args.audit_root,
+        config_label=config_label,
+        # CLI invocations default to staging-only — the LLM merger
+        # belongs to the bot process, not a one-shot launchd job.
+        conflict_auto_merge=auto_merge,
+        merger=_noop_merger,
+        notifier=_stderr_notifier,
+    )
+
+    if args.run_once:
+        watcher.run_once()
+        return 0
+
+    # No mode flag given — same behavior as --run-once for safety.
+    watcher.run_once()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_conflict_watcher.py
+++ b/tests/test_conflict_watcher.py
@@ -271,3 +271,52 @@ def test_audit_records_error_when_merger_raises(tmp_path: Path) -> None:
     # Canonical and conflict files are both still present — nothing was lost.
     assert canonical.exists()
     assert conflict.exists()
+
+
+# ---------------------------------------------------------------------------
+# CLI: ``python -m kernel.conflict_watcher --run-once``
+# ---------------------------------------------------------------------------
+
+
+def test_cli_run_once_executes_one_scan_and_exits(tmp_path: Path) -> None:
+    """``--run-once`` must perform a single ``run_once`` scan and exit cleanly.
+
+    launchd schedules the cadence; we never want this CLI invocation to
+    fall into a long-running ``run_loop``.
+    """
+    from kernel.conflict_watcher import main
+
+    vault = tmp_path / "vault"
+    audit = tmp_path / "audit"
+    vault.mkdir(parents=True, exist_ok=True)
+
+    # Dropping a conflict file gives the scan something to do without
+    # any merger or notifier wiring (we go down the staging branch).
+    canonical = vault / "journal" / "2026-04-29.md"
+    conflict = vault / "journal" / "2026-04-29 (Conflict 2026-04-29 18-21).md"
+    canonical.parent.mkdir(parents=True, exist_ok=True)
+    canonical.write_text("# canonical\n", encoding="utf-8")
+    conflict.write_text("# canonical\nphone\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--run-once",
+            "--vault-root",
+            str(vault),
+            "--audit-root",
+            str(audit),
+        ]
+    )
+
+    assert exit_code == 0
+    # The conflict was staged into _inbox/_conflicts/.
+    staged = list((vault / "_inbox" / "_conflicts").rglob("*.md"))
+    assert len(staged) == 1
+
+
+def test_cli_rejects_unknown_args(tmp_path: Path) -> None:
+    """Argparse must reject malformed flags so misconfigured plists fail fast."""
+    from kernel.conflict_watcher import main
+
+    with pytest.raises(SystemExit):
+        main(["--not-a-real-flag"])

--- a/tests/test_launchd_plists.py
+++ b/tests/test_launchd_plists.py
@@ -1,0 +1,173 @@
+"""Tests for the launchd plists under ``infra/launchd/``.
+
+These tests verify install-time correctness without actually invoking
+``launchctl load`` (which would have system-level side effects). We
+check that:
+
+  1. Each plist parses as a valid plist via ``plistlib``.
+  2. Each plist's ``Label`` matches its filename stem.
+  3. Schedule fields (``StartCalendarInterval`` / ``StartInterval``) match
+     the proactive cadences declared in ``configs/default.yaml`` and
+     ``kernel/PROACTIVE.md``.
+  4. The bot plist sets ``KeepAlive=True`` and ``RunAtLoad=True`` so
+     launchd auto-restarts it on crash and starts it at install.
+  5. Every plist invokes Python via ``python -m kernel.<module>`` —
+     i.e., they don't bake absolute paths to scripts and they exercise
+     the same module entrypoints the tests already exercise.
+  6. Each plist's ``EnvironmentVariables`` block carries a
+     ``TELEGRAM_BOT_TOKEN`` key (the README documents how to populate it).
+"""
+
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LAUNCHD_DIR = _REPO_ROOT / "infra" / "launchd"
+
+_PLIST_FILENAMES = (
+    "com.jasonchi.pa.daily-digest.plist",
+    "com.jasonchi.pa.weekly-digest.plist",
+    "com.jasonchi.pa.reminder-check.plist",
+    "com.jasonchi.pa.conflict-watcher.plist",
+    "com.jasonchi.pa.bot.plist",
+)
+
+
+def _load(filename: str) -> dict:
+    """Parse a plist into a Python dict."""
+    path = _LAUNCHD_DIR / filename
+    with path.open("rb") as handle:
+        return plistlib.load(handle)
+
+
+@pytest.mark.parametrize("filename", _PLIST_FILENAMES)
+def test_plist_parses_as_valid_plist(filename: str) -> None:
+    """Every plist must be syntactically valid XML / plist."""
+    parsed = _load(filename)
+    assert isinstance(parsed, dict)
+
+
+@pytest.mark.parametrize("filename", _PLIST_FILENAMES)
+def test_plist_label_matches_filename_stem(filename: str) -> None:
+    """``Label`` must equal the filename without ``.plist`` — launchd's invariant."""
+    parsed = _load(filename)
+    expected = filename.removesuffix(".plist")
+    assert parsed.get("Label") == expected
+
+
+@pytest.mark.parametrize("filename", _PLIST_FILENAMES)
+def test_plist_invokes_python_module(filename: str) -> None:
+    """Each plist must run ``python ... -m kernel.<module>`` (no absolute script paths)."""
+    parsed = _load(filename)
+    program_arguments = parsed.get("ProgramArguments")
+    assert isinstance(program_arguments, list) and program_arguments, (
+        f"{filename} must declare ProgramArguments"
+    )
+    # Some entry in argv must reference the Python interpreter — either
+    # directly (``/usr/bin/python3.12``) or via env-shim (``python3.12``
+    # following ``/usr/bin/env``). Exact name is install-time tunable.
+    assert any("python" in arg.lower() for arg in program_arguments), (
+        f"{filename} ProgramArguments lacks a python reference: {program_arguments!r}"
+    )
+    # ``-m kernel.<module>`` must appear consecutively somewhere after.
+    assert "-m" in program_arguments
+    m_index = program_arguments.index("-m")
+    assert m_index + 1 < len(program_arguments), (
+        f"{filename} declared -m without a module argument"
+    )
+    module_arg = program_arguments[m_index + 1]
+    assert module_arg.startswith("kernel."), (
+        f"{filename} must invoke a kernel.* module, got {module_arg!r}"
+    )
+
+
+@pytest.mark.parametrize("filename", _PLIST_FILENAMES)
+def test_plist_environment_variables_carry_token_key(filename: str) -> None:
+    """Every plist exposes ``TELEGRAM_BOT_TOKEN`` (placeholder is fine for templating)."""
+    parsed = _load(filename)
+    env = parsed.get("EnvironmentVariables")
+    assert isinstance(env, dict), (
+        f"{filename} must declare EnvironmentVariables dict"
+    )
+    assert "TELEGRAM_BOT_TOKEN" in env, (
+        f"{filename} EnvironmentVariables missing TELEGRAM_BOT_TOKEN"
+    )
+
+
+def test_daily_digest_runs_at_8am() -> None:
+    """daily-digest fires once a day at 08:00 via StartCalendarInterval."""
+    parsed = _load("com.jasonchi.pa.daily-digest.plist")
+    schedule = parsed.get("StartCalendarInterval")
+    assert schedule == {"Hour": 8, "Minute": 0}
+    # Must invoke the daily-digest task explicitly.
+    assert "daily-digest" in parsed["ProgramArguments"]
+
+
+def test_weekly_digest_runs_sunday_6pm() -> None:
+    """weekly-digest fires Sunday (Weekday=0) at 18:00."""
+    parsed = _load("com.jasonchi.pa.weekly-digest.plist")
+    schedule = parsed.get("StartCalendarInterval")
+    assert schedule == {"Weekday": 0, "Hour": 18, "Minute": 0}
+    assert "weekly-digest" in parsed["ProgramArguments"]
+
+
+def test_reminder_check_runs_every_5_minutes() -> None:
+    """reminder-check uses StartInterval=300 — matches reminder_check_interval_min=5."""
+    parsed = _load("com.jasonchi.pa.reminder-check.plist")
+    assert parsed.get("StartInterval") == 300
+    assert "check-reminders" in parsed["ProgramArguments"]
+
+
+def test_conflict_watcher_runs_every_minute() -> None:
+    """conflict-watcher uses StartInterval=60 — matches conflict_watcher_interval_min=1."""
+    parsed = _load("com.jasonchi.pa.conflict-watcher.plist")
+    assert parsed.get("StartInterval") == 60
+    # Single-shot scan: we want each launchd invocation to exit, not loop.
+    assert "--run-once" in parsed["ProgramArguments"]
+
+
+def test_bot_plist_keeps_alive_and_runs_at_load() -> None:
+    """The polling-loop bot must auto-restart on crash and start at install."""
+    parsed = _load("com.jasonchi.pa.bot.plist")
+    assert parsed.get("KeepAlive") is True
+    assert parsed.get("RunAtLoad") is True
+    # No schedule keys — long-running process, not periodic.
+    assert "StartInterval" not in parsed
+    assert "StartCalendarInterval" not in parsed
+    # Bot module is the polling-loop entrypoint.
+    assert "kernel.telegram_bridge" in parsed["ProgramArguments"]
+
+
+@pytest.mark.parametrize("filename", _PLIST_FILENAMES)
+def test_plist_declares_log_paths(filename: str) -> None:
+    """Each plist routes stdout + stderr to a log file for post-mortem inspection."""
+    parsed = _load(filename)
+    assert "StandardOutPath" in parsed, f"{filename} missing StandardOutPath"
+    assert "StandardErrorPath" in parsed, f"{filename} missing StandardErrorPath"
+
+
+@pytest.mark.parametrize("filename", _PLIST_FILENAMES)
+def test_plist_declares_working_directory(filename: str) -> None:
+    """Each plist must set WorkingDirectory so relative imports/paths resolve."""
+    parsed = _load(filename)
+    assert "WorkingDirectory" in parsed, f"{filename} missing WorkingDirectory"
+
+
+def test_install_readme_exists_and_documents_launchctl() -> None:
+    """The install README walks the user through load / list / unload."""
+    readme = _LAUNCHD_DIR / "README.md"
+    assert readme.exists(), "infra/launchd/README.md is required"
+    content = readme.read_text(encoding="utf-8")
+    for needle in ("launchctl load", "launchctl list", "launchctl unload", "TELEGRAM_BOT_TOKEN"):
+        assert needle in content, f"README.md missing reference to {needle!r}"
+
+
+def test_plist_labels_are_unique() -> None:
+    """No two plists may share a launchd Label — they'd collide on load."""
+    labels = [_load(f)["Label"] for f in _PLIST_FILENAMES]
+    assert len(set(labels)) == len(labels), f"duplicate labels: {labels}"


### PR DESCRIPTION
## Summary

- Adds the five launchd plists under `infra/launchd/` that schedule the proactive loops on the Mac mini host (daily/weekly digests, reminder dispatcher, conflict watcher, bot keep-alive).
- Cadences match `configs/default.yaml`: daily 08:00, weekly Sunday 18:00, reminders every 5 min (`StartInterval=300`), conflict watcher every 1 min (`StartInterval=60`), bot long-running with `KeepAlive=true` + `RunAtLoad=true`.
- Extends `kernel/conflict_watcher.py` with a minimal `--run-once` CLI so each launchd invocation performs a single scan and exits; `run_loop()` remains for foreground debug. Default mode is staging-only (the LLM merger belongs to the bot process, not a one-shot subprocess).
- `infra/launchd/README.md` documents templating `__PROJECT_ROOT__` + `__TELEGRAM_BOT_TOKEN__` placeholders, `launchctl load/list/unload`, and platform caveats (Full Disk Access for the Drive vault, `python3.12` discovery via `/usr/bin/env`, the flock interaction with KeepAlive throttling).

Closes #12

## Test plan

- [x] `pytest -q` — 319 passed (280 prior + 37 new launchd plist tests + 2 new conflict-watcher CLI tests)
- [x] `plutil -lint infra/launchd/*.plist` — all OK
- [x] Each plist's `Label` matches its filename, schedule fields match the spec, `EnvironmentVariables` carries `TELEGRAM_BOT_TOKEN`, every `ProgramArguments` invokes `python -m kernel.<module>`
- [x] Bot plist has `KeepAlive=True` and `RunAtLoad=True`; no schedule keys
- [ ] Install verification on the Mac mini: render via the README's sed snippet, `launchctl load -w`, confirm `launchctl list | grep com.jasonchi.pa` shows all five labels, and audit log fills with scheduled invocations